### PR TITLE
Remove MATH336 from CC-Elective exclusion list

### DIFF
--- a/content/undergraduate/cc-electives.md
+++ b/content/undergraduate/cc-electives.md
@@ -158,7 +158,7 @@
 "MATH3XX", "All courses with the code MATH3XX", ""
 "MATH4XX", "All courses with the code MATH4XX", ""
 "MATH5XX", "All courses with the code MATH5XX", ""
-"", "EXCEPT", " MATH310, MATH344 and MATH336 are not eligible."
+"", "EXCEPT", " MATH310 and MATH344 are not eligible."
 :::
 
 {#PHIL}


### PR DESCRIPTION
MATH336 is no longer excluded from eligible CC-Elective courses in the MATH section.

https://claude.ai/code/session_01K9xzAf4HXrGj8eBw4wa6fP